### PR TITLE
expose ipfs API port by default

### DIFF
--- a/ipfs.toml
+++ b/ipfs.toml
@@ -2,7 +2,7 @@
 name = "ipfs"
 image = "eris/ipfs"
 data_container = true
-ports = ["4001:4001", "5001", "8080:8080"]
+ports = ["4001:4001", "5001:5001", "8080:8080"]
 user = "root"
 
 [maintainer]


### PR DESCRIPTION
since `eris files` now uses the API exclusively, port 5001 should be exposed by default